### PR TITLE
improve: block player after wrong answer until another player succeeds (closes #4)

### DIFF
--- a/client/css/main.css
+++ b/client/css/main.css
@@ -392,3 +392,19 @@ svg pattern path { stroke-width: 2; }
     border-radius: 12px;
     padding: 3px 10px;
 }
+
+/* ── Blocked-after-wrong message ──────────────────────── */
+#blockedMsg {
+    position: fixed;
+    top: 12vh;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(220, 53, 69, 0.92);
+    color: #fff;
+    padding: 10px 22px;
+    border-radius: 20px;
+    font-size: 0.85em;
+    z-index: 300;
+    pointer-events: none;
+    text-align: center;
+}

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -47,6 +47,9 @@ $(function () {
                     pendingSelection = null
                 }
             } else {
+                if(data.blocked) {
+                    setPlayerBlocked(true)
+                }
                 endTurn('alreadyBlocked')
             }
         } catch(e) {console.log(e)}
@@ -122,6 +125,14 @@ $(function () {
 
     socket.on('turn_ended', function() {
         dismissTurnToast()
+    })
+
+    socket.on('you_are_blocked', function() {
+        setPlayerBlocked(true)
+    })
+
+    socket.on('all_unblocked', function() {
+        setPlayerBlocked(false)
     })
 
     socket.on('solution_found', function (json) {
@@ -214,6 +225,18 @@ $(function () {
         $('#playerStats').html(html).show();
     }
 
+    var _playerBlocked = false
+    function setPlayerBlocked(blocked) {
+        _playerBlocked = blocked
+        if(blocked) {
+            if(!$('#blockedMsg').length) {
+                $('body').append('<div id="blockedMsg">❌ Wrong — wait for another player to find a set</div>')
+            }
+        } else {
+            $('#blockedMsg').remove()
+        }
+    }
+
     var _turnToastEl = null
     var _turnToastInterval = null
 
@@ -275,7 +298,7 @@ $(function () {
     function buildCard(card) {
         var cardContentEl = $(`<div id="${card.cid}" class="content"></div>`)
         cardContentEl.click(function () {
-            if(!ourTurn) { askForTurn() }
+            if(!ourTurn) { if(_playerBlocked) { return } askForTurn() }
             $(this).toggleClass('selected')
             checkAndSendSolution('.selected')
         })

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -6,6 +6,7 @@ $(function () {
     ,   socket = io()
     ,   board = {}
     ,   ourTurn = false
+    ,   otherPlayerHasTurn = false
     ,   timer = null
     ,   pendingSelection = null
 
@@ -40,6 +41,7 @@ $(function () {
         try{
             var data = JSON.parse(json)
             if(data.success) { 
+                otherPlayerHasTurn = false
                 startTurn(data.countdown)
                 // Send buffered selection if player had already picked 3 cards
                 if(pendingSelection) {
@@ -109,6 +111,7 @@ $(function () {
     socket.on('turn_started', function(json) {
         try {
             var data = JSON.parse(json)
+            otherPlayerHasTurn = true
             showTurnToast('Player ' + data.playerNum + '’s turn', data.countdown)
             // Mirror countdown for observers
             _turnToastInterval = setInterval(function(){
@@ -117,6 +120,7 @@ $(function () {
                     $('#turnToastTimer').text((remaining - 0.1).toFixed(1))
                 } else {
                     clearInterval(_turnToastInterval); _turnToastInterval = null
+                    otherPlayerHasTurn = false
                     dismissTurnToast()
                 }
             }, 100)
@@ -124,6 +128,7 @@ $(function () {
     })
 
     socket.on('turn_ended', function() {
+        otherPlayerHasTurn = false
         dismissTurnToast()
     })
 
@@ -132,12 +137,14 @@ $(function () {
     })
 
     socket.on('all_unblocked', function() {
+        otherPlayerHasTurn = false
         setPlayerBlocked(false)
     })
 
     socket.on('solution_found', function (json) {
         try { 
             var data = JSON.parse(json)
+            otherPlayerHasTurn = false
             dismissTurnToast()
             //handle correct solution
             data.oldCardsCids.forEach(function (cid) {
@@ -298,7 +305,7 @@ $(function () {
     function buildCard(card) {
         var cardContentEl = $(`<div id="${card.cid}" class="content"></div>`)
         cardContentEl.click(function () {
-            if(!ourTurn) { if(_playerBlocked) { return } askForTurn() }
+            if(!ourTurn) { if(_playerBlocked || otherPlayerHasTurn) { return } askForTurn() }
             $(this).toggleClass('selected')
             checkAndSendSolution('.selected')
         })

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -98,10 +98,15 @@ $(function () {
             } else {
                 reason = 'bad solution'
                 console.log(data.error)
-                // Flash red + shake on wrong answer
-                var wrongCards = $('.content.selected')
-                wrongCards.addClass('wrong')
-                setTimeout(function() { wrongCards.removeClass('wrong') }, 500)
+                if(data.error === 'time_out') {
+                    // Countdown expired — show blocked banner immediately
+                    setPlayerBlocked(true)
+                } else {
+                    // Flash red + shake on wrong answer
+                    var wrongCards = $('.content.selected')
+                    wrongCards.addClass('wrong')
+                    setTimeout(function() { wrongCards.removeClass('wrong') }, 500)
+                }
             }
             renderStatsUpdate(data.stats)
             endTurn(reason)

--- a/server/app.js
+++ b/server/app.js
@@ -305,12 +305,28 @@ io.on('connection', function(socket){
 						error: 'time_out',
 						stats: stats
 					}));
+					// Notify others: countdown ended
+					socket.broadcast.emit('turn_ended', JSON.stringify({ reason: 'timeout' }));
+					// Notify blocked state
+					var everyoneUnblocked = !session.isBlocked(socket.id);
+					if(everyoneUnblocked) {
+						socket.emit('all_unblocked', '{}');
+						socket.broadcast.emit('all_unblocked', '{}');
+					} else {
+						socket.emit('you_are_blocked', '{}');
+					}
 				}, session.turnTimeout);
 			}
 			// Solo: no timeout — grant an extended window (30s) just to auto-release
 			else {
 				session.timeout = setTimeout(function () {
-					session.turnEnd('countdown');
+					var stats = session.turnEnd('countdown');
+					socket.emit('solution_response',JSON.stringify({
+						correct: false,
+						error: 'time_out',
+						stats: stats
+					}));
+					socket.emit('you_are_blocked', '{}');
 				}, 30000);
 			}
 			msg = { success: true, countdown: solo ? 30000 : session.turnTimeout };

--- a/server/app.js
+++ b/server/app.js
@@ -399,10 +399,16 @@ io.on('connection', function(socket){
 				error: 'just_wrong',
 				stats: stats
 			}));
-			// Notify other players: turn ended, and whether the solver is now blocked
-			socket.broadcast.emit('turn_ended', JSON.stringify({ reason: 'wrong', blockedPid: socket.id }));
-			// Tell the solver they are blocked
-			if(session.isBlocked(socket.id)) {
+			// Notify other players: turn ended
+			socket.broadcast.emit('turn_ended', JSON.stringify({ reason: 'wrong' }));
+			// Check if all players are now unblocked (everyone was wrong)
+			var everyoneUnblocked = !session.isBlocked(socket.id);
+			if(everyoneUnblocked) {
+				// All players were blocked and are now reset — notify everyone
+				socket.emit('all_unblocked', '{}');
+				socket.broadcast.emit('all_unblocked', '{}');
+			} else {
+				// Only this player is blocked
 				socket.emit('you_are_blocked', '{}');
 			}
 		}

--- a/server/app.js
+++ b/server/app.js
@@ -127,6 +127,7 @@ function Session() {
 	this.turnTimeout = 3000;
 	this.timeout = null;
 	this.lastActivity = Date.now();
+	this.blockedPlayers = {}; // pids blocked after wrong answer
 
 	var that = this;
 	this.deck.draw(12).forEach(function (c) {
@@ -209,6 +210,9 @@ Session.prototype.turnFor = function(pid) {
 	if(this.status !== 'active') {
 		throw new Error('session already blocked');
 	}
+	if(this.blockedPlayers[pid]) {
+		throw new Error('player is blocked after wrong answer');
+	}
 	this.activePlayer = pid;
 	this.status = 'blocked';
 	console.log('Turn: ' + pid);
@@ -218,8 +222,20 @@ Session.prototype.turnEnd = function (reason) {
 	clearTimeout(this.timeout);
 	stats = this.updateScoreForActivePlayer(reason);
 	console.log('Turn end: ' + this.activePlayer + ' (' + reason + ')');
+	if(reason === 'bad solution' || reason === 'countdown') {
+		this.blockedPlayers[this.activePlayer] = true;
+		// If all players are now blocked, unblock everyone
+		var activePids = Object.keys(this.players);
+		var allBlocked = activePids.every(function(pid) { return this.blockedPlayers[pid]; }, this);
+		if(allBlocked) { this.blockedPlayers = {}; }
+	} else if(reason === 'good solution') {
+		this.blockedPlayers = {}; // unblock everyone on success
+	}
 	this.activePlayer = null;
 	return stats
+}
+Session.prototype.isBlocked = function(pid) {
+	return !!this.blockedPlayers[pid];
 }
 
 //--------
@@ -299,7 +315,8 @@ io.on('connection', function(socket){
 			}
 			msg = { success: true, countdown: solo ? 30000 : session.turnTimeout };
 		} catch(e) {
-			msg = { success: false };
+			var isBlocked = session && session.isBlocked && session.isBlocked(socket.id);
+			msg = { success: false, blocked: isBlocked };
 			console.log(e);
 		}
 		socket.emit('solution_block_response', JSON.stringify(msg));
@@ -365,6 +382,8 @@ io.on('connection', function(socket){
 				allPlayerStats: allStats
 			}));
 
+			// Unblock all players on success
+			socket.broadcast.emit('all_unblocked', '{}');
 			socket.broadcast.emit('solution_found', JSON.stringify({
 				oldCardsCids: solutionCids,
 				newCards: newCards,
@@ -380,8 +399,12 @@ io.on('connection', function(socket){
 				error: 'just_wrong',
 				stats: stats
 			}));
-			// Notify other players to cancel their countdown
-			socket.broadcast.emit('turn_ended', JSON.stringify({ reason: 'wrong' }));
+			// Notify other players: turn ended, and whether the solver is now blocked
+			socket.broadcast.emit('turn_ended', JSON.stringify({ reason: 'wrong', blockedPid: socket.id }));
+			// Tell the solver they are blocked
+			if(session.isBlocked(socket.id)) {
+				socket.emit('you_are_blocked', '{}');
+			}
 		}
 	});
 


### PR DESCRIPTION
## What

Implements the behaviour requested in #4: after a player submits an incorrect solution, they are blocked from claiming a new turn until another player finds a valid set. If all players end up blocked simultaneously, everyone is unblocked so the game can continue.

## How it works

- **Server**: `Session` tracks a `blockedPlayers` set. `turnEnd('bad solution')` adds the solver. `turnEnd('good solution')` clears it entirely. Auto-unblocks all if everyone is blocked.
- **Client**: blocked players see a red banner ("❌ Wrong — wait for another player to find a set") and card clicks are ignored until `all_unblocked` is received.
- Two new socket events: `you_are_blocked` (to the solver) and `all_unblocked` (broadcast on success).

## 🔗 Live demo

https://patterns-i8-block-after-wrong.onrender.com

---

*This PR was opened by an OpenClaw AI client, used to playfully explore what's possible.*
