### PR TITLE
Set up development environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this is
+"Patterns" is a single-process, browser-based multiplayer card game (a "Set"-style game). There is no database or auxiliary service — all game state lives in memory.
+
+- Server entry: `server/app.js` (`connect` + `serve-static` HTTP server that also serves the static `client/` and runs a `socket.io` WebSocket backend). Listens on `process.env.PORT || 3000`.
+- Client: static `client/index.html` + `client/js/app.js` (vanilla JS + jQuery/chardin.js from CDN; the socket.io client is served locally at `/socket.io/socket.io.js`).
+
+### Running
+- Start the server with `npm start` (runs `node server/app.js`), then open `http://localhost:3000`. There is no separate dev/watch script — `start` is used for both dev and prod, and there is no hot reload, so restart the process after editing `server/app.js`.
+
+### Testing / linting
+- There is no automated test suite. `npm test` is only a placeholder that exits 1.
+- There is no working lint script: the repo ships a legacy `.eslintrc` and lists only `eslint-plugin-react` as a devDependency (ESLint itself is not installed and the config predates flat config). Use `node --check <file>` for a quick syntax check instead.
+
+### How to verify gameplay end-to-end
+- Opening `http://localhost:3000` auto-creates a session and deals 12 cards; a "How to play" popup shows on first load (dismiss with "Got it").
+- `client/js/app.js` exposes a console helper: run `debugPatterns.checkSets()` in the browser console to list valid sets (card IDs). Click a card to claim the turn, then select 2 more; a valid triplet scores +1 (`pts`). Multiplayer = open multiple tabs to the shared `#sid_...` URL.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for the "Patterns" card game and documents it for future agents.

- Verified `npm install` resolves all dependencies cleanly on Node `v22`.
- Ran the single-service app (`npm start` → `node server/app.js`) and confirmed it serves the client and socket.io backend on port `3000`.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the architecture, run command, the lack of a test/lint setup, and how to verify gameplay via the `debugPatterns.checkSets()` console helper.

No application code was modified.

## Hello-world verification
Opened `http://localhost:3000`, found a valid set with the built-in console helper, selected the 3 cards, and the score (`pts`) incremented from 0 to 1.

[patterns_game_score_point.mp4](https://cursor.com/agents/bc-c9da0239-2ed9-43d0-b1d8-c3d1a5226b1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpatterns_game_score_point.mp4)

[Patterns game with pts at 1](https://cursor.com/agents/bc-c9da0239-2ed9-43d0-b1d8-c3d1a5226b1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpatterns_pts_1.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9da0239-2ed9-43d0-b1d8-c3d1a5226b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9da0239-2ed9-43d0-b1d8-c3d1a5226b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

